### PR TITLE
Add Data Access to top nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
           - API:
             - design/data-catalogue/api/endpoint-specification.md
             - design/data-catalogue/api/usage.md
+  - Data Access: https://eoepca.readthedocs.io/projects/data-access/
 #    - Usage:
 #      - usage/tutorials.md
 #      - usage/howtos.md


### PR DESCRIPTION
Goal: All building block docs pages are featured in the top nav like in this [example](https://eoepca.readthedocs.io/projects/data-access).

<img width="632" alt="image" src="https://github.com/EOEPCA/system-architecture/assets/3404817/2409ed66-bbef-4b95-85c6-c0a97104d658">